### PR TITLE
Beanstalk module review and improvements

### DIFF
--- a/modules/beanstalk/README.md
+++ b/modules/beanstalk/README.md
@@ -1,9 +1,9 @@
-# AWS Elastic Beanstalk .NET Framework
+# AWS Elastic Beanstalk .NET
 
-Terraform module which manages AWS Elastic Beanstalk resources related to Windows Server 2019 (latest) with a sample .NET Framework 4 application (_WebServer tier_), leveraging Application Load Balancer and Auto Scaling Group. What it manages:
+Terraform module which manages AWS Elastic Beanstalk resources related to Windows Server 2022 (latest) with a sample ASP.NET application (_WebServer tier_), leveraging Application Load Balancer and Auto Scaling Group. What it manages:
 
 - IAM resources (role and instance profile)
-- Security group
+- Security groups
 - Beanstalk application
 - Beanstalk environment
 - Application Load Balancer
@@ -16,18 +16,19 @@ Terraform module which manages AWS Elastic Beanstalk resources related to Window
 
 ## Variables description
 
-- **vpc_id (string)**: VPC ID where the environment will be deployed
-- **private_subnets (list(string))**: Private subnets where the application instances will be deployed
-- **public_subnets (list(string))**: Public subnets where the Application Load Balancer will be deployed
-- **beanstalk_net_framework_application_name (string)**: Beanstalk application name
-- **beanstalk_net_framework_application_description (string)**: Beanstalk application description
-- **beanstalk_net_framework_environment_name (string)**: Beanstalk environment name
-- **ec2_instance_type (string)**: EC2 instance type that is going to be deployed by Beanstalk (default = t3.medium)
-- **asg_min_instances (number)**: Minimum number of instances to be addressed via ASG (default = 1)
-- **asg_max_instances (number)**: Maximum number of instances to be addressed via ASG (default = 2)
-- **tags (map(any))**: Tags to be applied
-- **key_name (string)**: Key pair to securely log into the EC2 instances
-- **acm_arn (string)**: ACM certificate ARN - only required if HTTPS needs to be enabled - an _HTTP to HTTPS_ redirect rule will also be created at the Application Load Balancer (default = "")
+- **region (string)**: AWS Region where the resources should be deployed (optional / default = us-east-1)
+- **vpc_id (string)**: VPC ID where the environment will be deployed. If not set, Default VPC will be used (optional / default = null)
+- **private_subnets (list(string))**: Private subnets where the application instances will be deployed. If not set, private subnets from Default VPC will be used based on tag:value format _Tier:Private_ (optional / default = null)
+- **public_subnets (list(string))**: Public subnets where the Application Load Balancer will be deployed. If not set, public subnets from Default VPC will be used based on tag:value format _Tier:Public_ (optional / default = null)
+- **beanstalk_net_windows_application_name (string)**: Beanstalk application name (required)
+- **beanstalk_net_windows_application_description (string)**: Beanstalk application description (required)
+- **beanstalk_net_windows_environment_name (string)**: Beanstalk environment name (required)
+- **ec2_instance_type (string)**: EC2 instance type that is going to be deployed by Beanstalk (optional / default = t3.medium)
+- **asg_min_instances (number)**: Minimum number of instances to be addressed via ASG (optional / default = 1)
+- **asg_max_instances (number)**: Maximum number of instances to be addressed via ASG (optional / default = 2)
+- **tags (map(any))**: Tags to be applied (recommended)
+- **key_name (string)**: Key pair to securely log into the EC2 instances (required)
+- **acm_arn (string)**: ACM certificate ARN - only required if HTTPS needs to be enabled - an _HTTP to HTTPS_ redirect rule will also be created at the Application Load Balancer (optional / default = null)
 
 ## Usage
 
@@ -55,9 +56,11 @@ module "beanstalk" {
 ```
 ## Outputs
 
-- **beanstalk_net_framework_uri**: The URL to the Application Load Balancer for the Environment
-- **beanstalk_net_framework_cname**: Fully qualified DNS name for the Environment
+- **beanstalk_net_windows_uri**: The URL to the Application Load Balancer for the Environment
+- **beanstalk_net_windows_cname**: Fully qualified DNS name for the Environment
 
 ## Notes
 
-- [checkov scan](https://www.checkov.io/) may report [CKV2_AWS_5](https://docs.bridgecrew.io/docs/ensure-that-security-groups-are-attached-to-ec2-instances-or-elastic-network-interfaces-enis) issue, which validates if a security group is attached to EC2 instances or ENIs resources. This may fail because, in this module, the security group is attached to the [aws_elastic_beanstalk_environment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elastic_beanstalk_environment) resource, which is not evaluated by CKV2_AWS_5.
+- [checkov scan](https://www.checkov.io/) may report [CKV2_AWS_5](https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-networking-policies/ensure-that-security-groups-are-attached-to-ec2-instances-or-elastic-network-interfaces-enis) issue, which validates if a security group is attached to EC2 instances or ENIs resources. This may fail because, in this module, the security group is attached to the [aws_elastic_beanstalk_environment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elastic_beanstalk_environment) resource, which is not evaluated by CKV2_AWS_5.
+- [checkov scan](https://www.checkov.io/) may report [CKV2_AWS_312](https://docs.prismacloud.io/en/enterprise-edition/policy-reference/aws-policies/aws-general-policies/bc-aws-312) issue, which validates if the environment has enhanced reporting (_HealthStreamingEnabled_) option enabled on the _aws:elasticbeanstalk:healthreporting:system_ namespace. This may fail because this option is now related to the [_aws:elasticbeanstalk:cloudwatch:logs:health_ namespace](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-cloudwatchlogs-health).
+- The Elastic Beanstalk API creates two default security groups: one for the Elastic Load Balancer (_awseb-e-xxxxxxxx-stack-AWSEBLoadBalancerSecurityGroup-YYYYYYYYYY_) and one for the EC2 Instances (_awseb-e-xxxxxxxx-stack-AWSEBSecurityGroup-YYYYYYYYYY_). To avoid affecting the default behavior, this module creates two additional security groups to address any tailored inbound and outbound rules needed for the environment. Related GitHub issues: [link1](https://github.com/aws/elastic-beanstalk-roadmap/issues/44) / [link2](https://github.com/hashicorp/terraform-provider-aws/issues/2002).

--- a/modules/beanstalk/locals.tf
+++ b/modules/beanstalk/locals.tf
@@ -11,4 +11,149 @@ locals {
   ]
 
   inbound_ports = [80, 443]
+
+  eb_environment_settings = [
+    {
+      namespace = "aws:ec2:vpc"
+      name      = "VPCId"
+      value     = var.vpc_id == null ? data.aws_vpc.default_vpc_id.id : var.vpc_id
+    },
+    {
+      namespace = "aws:ec2:vpc"
+      name      = "Subnets"
+      value     = join(",", var.private_subnets == null ? data.aws_subnets.default_private_subnets.ids : var.private_subnets)
+    },
+    {
+      namespace = "aws:ec2:vpc"
+      name      = "AssociatePublicIpAddress"
+      value     = false
+    },
+    {
+      namespace = "aws:ec2:vpc"
+      name      = "ELBSubnets"
+      value     = join(",", var.public_subnets == null ? data.aws_subnets.default_public_subnets.ids : var.public_subnets)
+    },
+    {
+      namespace = "aws:ec2:vpc"
+      name      = "ELBScheme"
+      value     = "public"
+    },
+    {
+      namespace = "aws:elasticbeanstalk:environment:process:default"
+      name      = "MatcherHTTPCode"
+      value     = "200-299,300-304,307-308"
+    },
+    {
+      namespace = "aws:elasticbeanstalk:environment"
+      name      = "LoadBalancerType"
+      value     = "application"
+    },
+    {
+      namespace = "aws:autoscaling:launchconfiguration"
+      name      = "InstanceType"
+      value     = var.ec2_instance_type
+    },
+    {
+      namespace = "aws:autoscaling:launchconfiguration"
+      name      = "RootVolumeType"
+      value     = "gp3"
+    },
+    {
+      namespace = "aws:autoscaling:launchconfiguration"
+      name      = "IamInstanceProfile"
+      value     = "${aws_iam_instance_profile.beanstalk_net_windows_instance_profile.name}"
+    },
+    {
+      namespace = "aws:autoscaling:launchconfiguration"
+      name      = "SecurityGroups"
+      value     = "${aws_security_group.secgroup_beanstalk_net_windows.id}"
+    },
+    {
+      namespace = "aws:autoscaling:launchconfiguration"
+      name      = "SSHSourceRestriction"
+      value     = "tcp,22,22,${aws_security_group.secgroup_beanstalk_net_windows.id}"
+      #  https://github.com/hashicorp/terraform-provider-aws/issues/2002
+      #  https://github.com/aws/elastic-beanstalk-roadmap/issues/44
+    },
+    {
+      namespace = "aws:autoscaling:launchconfiguration"
+      name      = "EC2KeyName"
+      value     = var.key_name
+    },
+    {
+      namespace = "aws:autoscaling:asg"
+      name      = "MinSize"
+      value     = var.asg_min_instances
+    },
+    {
+      namespace = "aws:autoscaling:asg"
+      name      = "MaxSize"
+      value     = var.asg_max_instances
+    },
+    {
+      namespace = "aws:elasticbeanstalk:managedactions"
+      name      = "ManagedActionsEnabled"
+      value     = "true"
+    },
+    {
+      namespace = "aws:elasticbeanstalk:managedactions"
+      name      = "PreferredStartTime"
+      value     = "Sat:00:00"
+    },
+    {
+      namespace = "aws:elasticbeanstalk:managedactions"
+      name      = "ServiceRoleForManagedUpdates"
+      value     = "AWSServiceRoleForElasticBeanstalkManagedUpdates"
+    },
+    {
+      namespace = "aws:elasticbeanstalk:managedactions:platformupdate"
+      name      = "UpdateLevel"
+      value     = "minor"
+    },
+    {
+      namespace = "aws:elasticbeanstalk:healthreporting:system"
+      name      = "SystemType"
+      value     = "enhanced"
+    },
+    {
+      namespace = "aws:elasticbeanstalk:healthreporting:system"
+      name      = "EnhancedHealthAuthEnabled"
+      value     = "true"
+    },
+    {
+      namespace = "aws:elasticbeanstalk:cloudwatch:logs:health"
+      name      = "HealthStreamingEnabled"
+      value     = "true"
+    },
+    {
+      namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+      name      = "StreamLogs"
+      value     = "true"
+    },
+    {
+      namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+      name      = "RetentionInDays"
+      value     = 7
+    },
+    {
+      namespace = "aws:elbv2:loadbalancer"
+      name      = "SecurityGroups"
+      value     = "${aws_security_group.secgroup_beanstalk_elb.id}"
+    },
+    {
+      namespace = var.acm_arn == null ? "aws:elbv2:listener:default" : "aws:elbv2:listener:443"
+      name      = "ListenerEnabled"
+      value     = "true"
+    },
+    {
+      namespace = var.acm_arn == null ? "aws:elbv2:listener:default" : "aws:elbv2:listener:443"
+      name      = "Protocol"
+      value     = var.acm_arn == null ? "HTTP" : "HTTPS"
+    },
+    {
+      namespace = var.acm_arn == null ? "aws:elbv2:listener:default" : "aws:elbv2:listener:443"
+      name      = "SSLCertificateArns"
+      value     = var.acm_arn == null ? "" : var.acm_arn
+    }
+  ]
 }

--- a/modules/beanstalk/main.tf
+++ b/modules/beanstalk/main.tf
@@ -10,21 +10,19 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-east-1"
+  region = var.region
 }
 
 ## Data
 
-data "aws_elastic_beanstalk_solution_stack" "net_framework" {
+data "aws_elastic_beanstalk_solution_stack" "net_windows" {
   most_recent = true
   name_regex  = "^64bit Windows Server 2022 (.*) running IIS (.*)$"
 }
 
-data "aws_vpc" "vpc_id" {
-  filter {
-    name   = "tag:Name"
-    values = ["VPC"]
-  }
+data "aws_vpc" "default_vpc_id" {
+  default = true
+
   lifecycle {
     postcondition {
       condition     = self.enable_dns_support == true
@@ -33,24 +31,32 @@ data "aws_vpc" "vpc_id" {
   }
 }
 
-data "aws_subnets" "private_subnets" {
+data "aws_subnets" "default_private_subnets" {
   filter {
-    name   = "tag:Tier"
-    values = ["Private"]
+    name   = "vpc-id"
+    values = [data.aws_vpc.default_vpc_id.id]
+  }
+
+  tags = {
+    Tier = "Private"
   }
 }
 
-data "aws_subnets" "public_subnets" {
+data "aws_subnets" "default_public_subnets" {
   filter {
-    name   = "tag:Tier"
-    values = ["Public"]
+    name   = "vpc-id"
+    values = [data.aws_vpc.default_vpc_id.id]
+  }
+
+  tags = {
+    Tier = "Public"
   }
 }
 
 ## IAM resources
 
-resource "aws_iam_role" "beanstalk_net_framework_ec2_role" {
-  name                = "iam_beanstalk_net_framework_ec2_role"
+resource "aws_iam_role" "beanstalk_net_windows_ec2_role" {
+  name                = "iam_beanstalk_net_windows_ec2_role"
   path                = "/"
   managed_policy_arns = local.managedpolicies_beanstalk_service_ec2_role
 
@@ -69,13 +75,13 @@ resource "aws_iam_role" "beanstalk_net_framework_ec2_role" {
   })
 }
 
-resource "aws_iam_instance_profile" "beanstalk_net_framework_instance_profile" {
-  name = "iam_beanstalk_net_framework_instance_profile"
-  role = aws_iam_role.beanstalk_net_framework_ec2_role.name
+resource "aws_iam_instance_profile" "beanstalk_net_windows_instance_profile" {
+  name = "iam_beanstalk_net_windows_instance_profile"
+  role = aws_iam_role.beanstalk_net_windows_ec2_role.name
 }
 
-resource "aws_iam_role" "beanstalk_net_framework_role" {
-  name                = "iam_beanstalk_net_framework_instance_role"
+resource "aws_iam_role" "beanstalk_net_windows_role" {
+  name                = "iam_beanstalk_net_windows_instance_role"
   path                = "/"
   managed_policy_arns = local.managedpolicies_beanstalk_service_role
 
@@ -94,12 +100,12 @@ resource "aws_iam_role" "beanstalk_net_framework_role" {
   })
 }
 
-## Security group
+## Security groups
 
-resource "aws_security_group" "secgroup_beanstalk_net_framework" {
-  name        = "secgroup_beanstalk_net_framework"
-  description = "Allows traffic to Beanstalk resources"
-  vpc_id      = data.aws_vpc.vpc_id.id
+resource "aws_security_group" "secgroup_beanstalk_elb" {
+  name        = "secgroup_beanstalk_elb"
+  description = "Allows traffic to ELB resources"
+  vpc_id      = var.vpc_id == null ? data.aws_vpc.default_vpc_id.id : var.vpc_id
 
   dynamic "ingress" {
     for_each = local.inbound_ports
@@ -107,8 +113,8 @@ resource "aws_security_group" "secgroup_beanstalk_net_framework" {
       from_port   = ingress.value
       to_port     = ingress.value
       protocol    = "tcp"
-      cidr_blocks = [data.aws_vpc.selected_vpc.cidr_block]
-      description = "Allow HTTP/HTTP inbound"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "Allow HTTP/HTTPS inbound from anyhwere"
     }
   }
 
@@ -124,151 +130,78 @@ resource "aws_security_group" "secgroup_beanstalk_net_framework" {
   tags = var.tags
 }
 
-## Beanstalk deployment (Windows + .NET Framework sample)
+resource "aws_security_group" "secgroup_beanstalk_net_windows" {
+  name        = "secgroup_beanstalk_net_windows"
+  description = "Allows traffic to Beanstalk resources"
+  vpc_id      = var.vpc_id == null ? data.aws_vpc.default_vpc_id.id : var.vpc_id
 
-resource "aws_elastic_beanstalk_application" "net_framework_application" {
-  name        = var.beanstalk_net_framework_application_name
-  description = var.beanstalk_net_framework_application_description
+  dynamic "ingress" {
+    for_each = local.inbound_ports
+    content {
+      from_port   = ingress.value
+      to_port     = ingress.value
+      protocol    = "tcp"
+      description = "Allow HTTP/HTTPS inbound from the ELB security group"
 
-  appversion_lifecycle {
-    service_role          = aws_iam_role.beanstalk_net_framework_role.arn
-    max_count             = 128
-    delete_source_from_s3 = true
-  }
-}
-
-resource "aws_elastic_beanstalk_environment" "net_framework_environment" {
-  name                = var.beanstalk_net_framework_environment_name
-  application         = aws_elastic_beanstalk_application.net_framework_application.name
-  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.net_framework.name
-  cname_prefix        = replace(var.beanstalk_net_framework_application_name, " ", "-")
-
-  setting {
-    namespace = "aws:ec2:vpc"
-    name      = "VPCId"
-    value     = data.aws_vpc.vpc_id.id
+      security_groups = [
+        "${aws_security_group.secgroup_beanstalk_elb.id}",
+      ]
+    }
   }
 
-  setting {
-    namespace = "aws:ec2:vpc"
-    name      = "Subnets"
-    value     = join(",", data.aws_subnets.private_subnet.ids)
-  }
-
-  setting {
-    namespace = "aws:autoscaling:launchconfiguration"
-    name      = "IamInstanceProfile"
-    value     = aws_iam_instance_profile.beanstalk_net_framework_instance_profile.name
-  }
-
-  setting {
-    namespace = "aws:ec2:vpc"
-    name      = "AssociatePublicIpAddress"
-    value     = false
-  }
-
-  setting {
-    namespace = "aws:ec2:vpc"
-    name      = "ELBSubnets"
-    value     = join(",", data.aws_subnets.public_subnet.ids)
-  }
-
-  setting {
-    namespace = "aws:elasticbeanstalk:environment:process:default"
-    name      = "MatcherHTTPCode"
-    value     = "200,300,301,302,303,304,307,308" # HTTP OK and redirect codes
-  }
-
-  setting {
-    namespace = "aws:elasticbeanstalk:environment"
-    name      = "LoadBalancerType"
-    value     = "application" # [classic, application, network]
-  }
-
-  setting {
-    namespace = "aws:autoscaling:launchconfiguration"
-    name      = "InstanceType"
-    value     = "t3.xlarge"
-  }
-
-  setting {
-    namespace = "aws:autoscaling:launchconfiguration"
-    name      = "SecurityGroups"
-    value     = aws_security_group.secgroup_beanstalk_net_framework.id
-  }
-
-  # setting {
-  #   namespace = "aws:autoscaling:launchconfiguration"
-  #   name      = "EC2KeyName"
-  #   value     = var.key_name
-  # }
-
-  setting {
-    namespace = "aws:ec2:vpc"
-    name      = "ELBScheme"
-    value     = "public" # [public, internal]
-  }
-
-  setting {
-    namespace = "aws:autoscaling:asg"
-    name      = "MinSize"
-    value     = var.asg_min_instances
-  }
-
-  setting {
-    namespace = "aws:autoscaling:asg"
-    name      = "MaxSize"
-    value     = var.asg_max_instances
-  }
-
-  setting {
-    namespace = "aws:elasticbeanstalk:healthreporting:system"
-    name      = "SystemType"
-    value     = "enhanced"
-  }
-
-  setting {
-    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
-    name      = "StreamLogs"
-    value     = true
-  }
-
-  setting {
-    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
-    name      = "RetentionInDays"
-    value     = 7
-  }
-
-  setting {
-    namespace = "aws:elbv2:listener:443"
-    name      = "ListenerEnabled"
-    value     = var.acm_arn == "" ? "false" : "true"
-  }
-
-  setting {
-    namespace = "aws:elbv2:listener:443"
-    name      = "Protocol"
-    value     = "HTTPS"
-  }
-
-  setting {
-    namespace = "aws:elbv2:listener:443"
-    name      = "SSLCertificateArns"
-    value     = var.acm_arn
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+    description      = "Allow all outbound"
   }
 
   tags = var.tags
 }
 
-# Sets HTTP redirect to HTTPS at the ALB when var.acm_arn is not null
+## Beanstalk deployment (Windows + ASP.NET sample)
+
+resource "aws_elastic_beanstalk_application" "net_windows_application" {
+  name        = var.beanstalk_net_windows_application_name
+  description = var.beanstalk_net_windows_application_description
+
+  appversion_lifecycle {
+    service_role          = aws_iam_role.beanstalk_net_windows_role.arn
+    max_count             = 128
+    delete_source_from_s3 = true
+  }
+}
+
+resource "aws_elastic_beanstalk_environment" "net_windows_environment" {
+  name                = var.beanstalk_net_windows_environment_name
+  application         = aws_elastic_beanstalk_application.net_windows_application.name
+  solution_stack_name = data.aws_elastic_beanstalk_solution_stack.net_windows.name
+  cname_prefix        = replace(var.beanstalk_net_windows_application_name, " ", "-")
+
+  dynamic "setting" {
+    for_each = local.eb_environment_settings
+    content {
+      namespace = setting.value.namespace
+      name      = setting.value.name
+      value     = setting.value.value
+    }
+  }
+
+  tags = var.tags
+}
+
+# Sets HTTP to HTTPS redirect at the ALB when var.acm_arn is not null
 
 data "aws_lb_listener" "http_listener" {
-  load_balancer_arn = aws_elastic_beanstalk_environment.net_framework_environment.load_balancers[0]
+
+  load_balancer_arn = aws_elastic_beanstalk_environment.net_windows_environment.load_balancers[0]
   port              = 80
 }
 
 resource "aws_lb_listener_rule" "redirect_http_to_https" {
-  count = var.acm_arn == "" ? 0 : 1
+  count = var.acm_arn == null ? 0 : 1
 
   listener_arn = data.aws_lb_listener.http_listener.arn
   priority     = 1

--- a/modules/beanstalk/outputs.tf
+++ b/modules/beanstalk/outputs.tf
@@ -1,7 +1,7 @@
-output "beanstalk_net_framework_uri" {
-  value = aws_elastic_beanstalk_environment.net_framework_environment.endpoint_url
+output "beanstalk_net_windows_uri" {
+  value = aws_elastic_beanstalk_environment.net_windows_environment.endpoint_url
 }
 
-output "beanstalk_net_framework_cname" {
-  value = aws_elastic_beanstalk_environment.net_framework_environment.cname
+output "beanstalk_net_windows_cname" {
+  value = aws_elastic_beanstalk_environment.net_windows_environment.cname
 }

--- a/modules/beanstalk/variables.tf
+++ b/modules/beanstalk/variables.tf
@@ -1,29 +1,38 @@
+variable "region" {
+  type        = string
+  description = "AWS Region where the resources will be deployed"
+  default     = "us-east-1"
+}
+
 variable "vpc_id" {
   type        = string
   description = "VPC ID where the environment will be deployed"
+  default     = null
 }
 
 variable "private_subnets" {
   type        = list(string)
   description = "Private subnets where the application will be deployed"
+  default     = null
 }
 
 variable "public_subnets" {
   type        = list(string)
   description = "Public subnets where the ALB will be deployed"
+  default     = null
 }
 
-variable "beanstalk_net_framework_application_name" {
+variable "beanstalk_net_windows_application_name" {
   type        = string
   description = "Beanstalk application name"
 }
 
-variable "beanstalk_net_framework_application_description" {
+variable "beanstalk_net_windows_application_description" {
   type        = string
   description = "Beanstalk application description"
 }
 
-variable "beanstalk_net_framework_environment_name" {
+variable "beanstalk_net_windows_environment_name" {
   type        = string
   description = "Beanstalk environment name"
 }
@@ -36,7 +45,7 @@ variable "ec2_instance_type" {
 
 variable "acm_arn" {
   type        = string
-  default     = ""
+  default     = null
   description = "ACM certificate ARN to enable HTTPS"
 }
 
@@ -59,5 +68,5 @@ variable "tags" {
 
 variable "key_name" {
   type        = string
-  description = "key pair to securely log into the EC2 instances"
+  description = "Key pair to securely log into the EC2 instances"
 }


### PR DESCRIPTION
Beanstalk module review and improvements:

- Moved the environment settings to _locals.tf_ to facilitate _main.tf_ maintenance;
- Added logic to use Default VPC in case VPC ID is not declared;
- Added logic to use private and public subnets from Default VPC based on tags in case they are no declared;
- Improved key pair and security groups assignments;
- Updated _README_.