### PR TITLE
Remove hard coded profile from managed-ad code sample

### DIFF
--- a/modules/managed-ad/main.tf
+++ b/modules/managed-ad/main.tf
@@ -15,7 +15,6 @@ terraform {
 
 provider "aws" {
   region  = var.aws_region
-  profile = "msft_python_automation"
 }
 
 ## Sets Admin secret


### PR DESCRIPTION
*Issue #8 :*

*Description of changes:*

Remove hard coded reference for a profile named `msft_python_automation`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
